### PR TITLE
fix flaky test: testObserverMethodsInParentOfAlternativeAndSpecializedBeans

### DIFF
--- a/webbeans-impl/src/main/java/org/apache/webbeans/util/SpecializationUtil.java
+++ b/webbeans-impl/src/main/java/org/apache/webbeans/util/SpecializationUtil.java
@@ -169,7 +169,18 @@ public class SpecializationUtil
     {
         for (Map<AnnotatedType<?>, BeansDeployer.ExtendedBeanAttributes<?>> beanAttributeMap : beanAttributesPerBda.values())
         {
-            beanAttributeMap.entrySet().removeIf(beanAttributesEntry -> disabledClasses.contains(beanAttributesEntry.getKey().getJavaClass()));
+            Set<AnnotatedType<?>> toRemove = new HashSet<>();
+            for (Map.Entry<AnnotatedType<?>, BeansDeployer.ExtendedBeanAttributes<?>> beanAttributesEntry : beanAttributeMap.entrySet())
+            {
+                if (disabledClasses.contains(beanAttributesEntry.getKey().getJavaClass()))
+                {
+                    toRemove.add(beanAttributesEntry.getKey());
+                }
+            }
+            for (AnnotatedType<?> annotatedType : toRemove)
+            {
+                beanAttributeMap.remove(annotatedType);
+            }
         }
     }
 


### PR DESCRIPTION
1. 
Running command:
`mvn -pl webbeans-impl  edu.illinois:nondex-maven-plugin:2.1.7:nondex  -Dtest=org.apache.webbeans.test.specalization.observer.pub.PublicObserverTest#testObserverMethodsInParentOfAlternativeAndSpecializedBeans -DnondexRuns=10`

Original error: 
![捕获](https://github.com/user-attachments/assets/efa57e91-ffd3-4017-9b21-6a066b1fce25)
error stack trace:
![捕获1](https://github.com/user-attachments/assets/9893c938-6d61-4e2b-b008-430526ad16d3)
Specific line of code: Line 172 at SpecializationUtil.java:
![捕获3](https://github.com/user-attachments/assets/1d260fed-a460-42f6-83d3-bbba684cdc01)

2. What I am trying to do:
    Adding a hashset to store all the elements that should be remove in beanAttributeMap, and remove all those elements in the 
    set together after looping through the whole map. This will avoid removing elements while looping with iteratorm, which 
    may cause IndexOutOfBoundException or ConcurrentModificationException when doing parallel programming .
3.  I used hashset to store the elements since the hashset is better on adding/deleting elements compare to ArrayList, which will 
     help reduce the time complexity.